### PR TITLE
removing the extern panic_halt in favor of our own panic function that will print info about the failure to the uart

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 #![no_main]
 #![feature(panic_info_message,asm)]
 
-extern crate panic_halt;
+// extern crate panic_halt;
 
 // use hifive1::hal::e310x::interrupt;
 use hifive1::sprint;
@@ -19,33 +19,33 @@ use riscv::interrupt;
 extern "C" fn eh_personality() {}
 
 
-// #[panic_handler]
-// fn panic(info: &core::panic::PanicInfo) -> ! {
-//     sprint!("Aborting: ");
-//     if let Some(p) = info.location() {
-//         sprintln!(
-//                  "line {}, file {}: {}",
-//                  p.line(),
-//                  p.file(),
-//                  info.message().unwrap()
-//         );
-//     }
-//     else {
-//         sprintln!("no information available.");
-//     }
-//     abort();
-// }
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    sprint!("Aborting: ");
+    if let Some(p) = info.location() {
+        sprintln!(
+                 "line {}, file {}: {}",
+                 p.line(),
+                 p.file(),
+                 info.message().unwrap()
+        );
+    }
+    else {
+        sprintln!("no information available.");
+    }
+    stop();
+}
 
 
-// #[no_mangle]
-// extern "C"
-// fn abort() -> ! {
-//     loop {
-//         unsafe {
-//             asm!("wfi");
-//         }
-//     }
-// }
+#[no_mangle]
+extern "C"
+fn stop() -> ! {
+    loop {
+        unsafe {
+            asm!("wfi");
+        }
+    }
+}
 
 // ///////////////////////////////////
 // / CONSTANTS
@@ -70,7 +70,7 @@ fn kmain() -> ! {
     let clocks = hifive1::clock::configure(p.PRCI, p.AONCLK, 320.mhz().into());
 
     // Configure UART for stdout
-    let mut _rx = hifive1::stdout::configure(
+    let mut rx = hifive1::stdout::configure(
         p.UART0,
         pin!(pins, uart0_tx),
         pin!(pins, uart0_rx),
@@ -85,7 +85,6 @@ fn kmain() -> ! {
         unsafe {
             riscv::asm::wfi();
         }
-
 
         // interrupt::free(|_| {
         //     if let Ok(w) = rx.read() {


### PR DESCRIPTION
when we panic, it'll show the line number of the file failure and other info and a user defined `&str`.

```
     Running `qemu-system-riscv32 -nographic -machine sifive_e,revb=true -m 128M -drive if=none,format=raw,file=hdd.dsk,id=foo -serial 'mon:stdio' -bios none -kernel target/riscv32imac-unknown-none-elf/debug/rustbox-hifive1-revb`
Hello World, This is Rust Box
Aborting: line 83, file src/main.rs: We're panicking!
```

I had to rename our local `abort` function to something else because it was being duplicated somewhere else in our linked code, so I named it `stop` for now.