### PR TITLE
kernel now just waits in main loop and keyboard input causes uart interrupts

### DIFF
--- a/examples/interrupt.rs
+++ b/examples/interrupt.rs
@@ -116,7 +116,7 @@ fn main() -> ! {
 
         let rplic = &*hifive1::hal::e310x::PLIC::ptr();
         for p in rplic.priority.iter() {
-            p.write(|w| w.bits(0));
+            p.write(|w| w.bits(Priority::P0.into()));
         }
 
         let mut plic = CorePeripherals::steal().plic;

--- a/examples/interrupt.rs
+++ b/examples/interrupt.rs
@@ -1,0 +1,139 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+
+use hifive1::hal::device::DevicePeripherals;
+use riscv_rt::entry;
+use hifive1::hal::prelude::*;
+use hifive1::hal::DeviceResources;
+use hifive1::hal::core::CorePeripherals;
+use hifive1::hal::core::plic::Priority;
+use hifive1::hal::e310x::Interrupt;
+use hifive1::{sprint, sprintln, pin};
+use core::sync::atomic::{AtomicUsize, Ordering};
+use riscv::register::{mstatus, mie};
+
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+static COUNTER2: AtomicUsize = AtomicUsize::new(0);
+
+#[no_mangle]
+pub unsafe extern "C" fn MachineTimer() {
+    COUNTER.fetch_add(1, Ordering::SeqCst);
+
+    let mut clint = CorePeripherals::steal().clint;
+    clint.mtimecmp.set_mtimecmp(clint.mtime.mtime() + 65536 / 2);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn MachineExternal() {
+    let mut plic = CorePeripherals::steal().plic;
+    let intr = plic.claim.claim().unwrap();
+    // sprintln!("Ext");
+    match intr {
+        Interrupt::RTC => {
+            COUNTER2.fetch_add(1, Ordering::SeqCst);
+
+            let rtc = &*hifive1::hal::e310x::RTC::ptr();
+            rtc.rtccmp.modify(|r, w| w.bits(r.bits() + 65536));
+            core::sync::atomic::compiler_fence(Ordering::SeqCst);
+        }
+        Interrupt::UART0 => {
+            let w = unsafe {
+                DeviceResources::steal().peripherals.UART0.rxdata.read().data().bits()
+            };
+            match w {
+                8 | 127 => {
+                    sprint!("{}{}{}", 8 as char, ' ', 8 as char);
+                },
+                10 | 13 => {
+                    sprintln!();
+                },
+                _ => {
+                    sprint!("{}", w as char);
+                }
+            }
+        }
+        _ => {
+            sprintln!("Unknown interrupt #{:?}!", intr);
+            panic!("Unknown interrupt");
+        }
+    }
+    plic.claim.complete(intr);
+}
+
+#[entry]
+fn main() -> ! {
+    let dr = DeviceResources::take().unwrap();
+    let p = dr.peripherals;
+    let pins = dr.pins;
+
+    // Configure clocks
+    let clocks = hifive1::clock::configure(p.PRCI, p.AONCLK, 64.mhz().into());
+
+    let serial_t = pin!(pins, uart0_tx).into_iof0();
+    let serial_r = pin!(pins, uart0_rx).into_iof0();
+    let serial = hifive1::hal::serial::Serial::new(
+        p.UART0, 
+        (serial_t, serial_r),
+        115_200.bps(),
+        clocks
+    );
+    let serial = serial.listen();
+    let (uart, (tx, rx)) = serial.free();
+
+    // Configure UART for stdout
+    hifive1::stdout::configure(uart, tx, rx, 115_200.bps(), clocks);
+
+    unsafe {
+        let uart = DeviceResources::steal().peripherals.UART0;
+        // Turn on interrupts for reading from uart
+        uart.ie.write(|w| w.txwm().bit(false).rxwm().bit(true));
+        // Enable receive, and set interrupt watermark to 1, so we should interrupt on any enqued data
+        uart.rxctrl.write(|w| w.enable().bit(true).counter().bits(0));
+    }
+
+
+    sprintln!("\nhello world!");
+
+    // Disable watchdog
+    let wdg = p.WDOG;
+    wdg.wdogcfg.modify(|_, w| w.enalways().clear_bit());
+
+    let mut rtc = p.RTC.constrain();
+    rtc.enable();
+    rtc.set_scale(0);
+    rtc.set_rtc(0);
+    rtc.set_rtccmp(10000);
+    rtc.enable();
+
+    let mut clint = dr.core_peripherals.clint;
+    clint.mtimecmp.set_mtimecmp(clint.mtime.mtime() + 10000);
+
+    unsafe {
+        mie::set_mtimer();
+        mstatus::set_mie();
+
+        let rplic = &*hifive1::hal::e310x::PLIC::ptr();
+        for p in rplic.priority.iter() {
+            p.write(|w| w.bits(0));
+        }
+
+        let mut plic = CorePeripherals::steal().plic;
+        plic.rtc.set_priority(Priority::P7);
+        plic.rtc.enable();
+        plic.uart0.enable();
+        plic.uart0.set_priority(Priority::P7);
+        plic.threshold.set(Priority::P0);
+        plic.mext.enable();
+    }
+
+    loop {
+        unsafe {
+            riscv::asm::wfi();
+        }
+        let cnt = COUNTER.load(Ordering::SeqCst);
+        let cnt2 = COUNTER2.load(Ordering::SeqCst);
+        // sprint!("\rCounter: {}, {}           ", cnt, cnt2);
+    }
+}

--- a/scripts/upload
+++ b/scripts/upload
@@ -46,3 +46,4 @@ $gdb $elf --batch -ex "set remotetimeout 240" -ex "target extended-remote localh
 kill %1
 
 fi
+echo

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,9 @@
 
 use hifive1::hal::core::clint;
 use hifive1::hal::e310x::CLINT;
+use hifive1::hal::e310x::PLIC;
+use hifive1::hal::e310x::Interrupt;
+use hifive1::hal::core::plic::Priority;
 use hifive1::sprint;
 use riscv::register::mstatus;
 use riscv_rt::entry;
@@ -11,6 +14,7 @@ use hifive1::hal::prelude::*;
 use hifive1::hal::DeviceResources;
 use hifive1::{pin, pins, sprintln};
 use hifive1::Led;
+use hifive1::hal::e310x::interrupt;
 use spin::Mutex;
 use lazy_static::lazy_static;
 
@@ -50,12 +54,11 @@ fn stop() -> ! {
 
 #[no_mangle]
 fn MachineTimer() {
-    // sprint!(".");
+    sprint!(".");
 
     riscv::interrupt::free(|_| {
-        update_time_compare(CLOCK_SPEED / 1000) 
+        update_time_compare(CLOCK_SPEED / 1000);
         // 1000 Timer interupts per second
-        // 
     })
 }
 
@@ -71,7 +74,58 @@ fn SupervisorTimer() {
 
 #[no_mangle]
 fn MachineExternal() {
-    sprint!(".");
+    let mut dr = unsafe {
+        DeviceResources::steal()
+    };
+
+    if let Some(interrupt) = dr.core_peripherals.plic.claim.claim() {
+        match interrupt {
+            Interrupt::UART0 => {
+                let pins = dr.pins;
+                let rgb_pins = pins!(pins, (led_red, led_green, led_blue));
+                let mut tleds = hifive1::rgb(rgb_pins.0, rgb_pins.1, rgb_pins.2);
+
+                let w = dr.peripherals.UART0.rxdata.read().data().bits();
+                match w {
+                    8 | 127 => {
+                        sprint!("{}{}{}", 8 as char, ' ', 8 as char);
+                    },
+                    10 | 13 => {
+                        sprintln!();
+                        tleds.0.off();
+                        tleds.1.off();
+                        tleds.2.on();
+                    },
+                    _ => {
+                        sprint!("{}", w as char);
+                        let c = (w % 7) + 1; // 1 to 8
+                        if c as u8 & 1 == 1 {
+                            tleds.2.on();
+                        } else {
+                            tleds.2.off();
+                        }
+                        if c as u8 & 2 == 2 {
+                            tleds.1.on();
+                        } else {
+                            tleds.1.off();
+                        }
+                        if c as u8 & 4 == 4 {
+                            tleds.0.on();
+                        } else {
+                            tleds.0.off();
+                        }
+                    }
+                }
+            }
+            _ => {
+                sprintln!("Unhandled Interrupt Handler for {:?}", interrupt);
+                panic!("Unknown Interrupt Handler");
+            }
+        }
+        dr.core_peripherals.plic.claim.complete(interrupt);
+    } else {
+        panic!("Why is there no interrupt cause??");
+    }
 }
 
 #[no_mangle]
@@ -79,16 +133,9 @@ fn DefaultHandler() {
     sprint!("Default!")
 }
 
-// interrupt!(WATCHDOG, periodic);
-
-fn periodic() {
-    sprint!(".");
-}
-
-// interrupt!(UART0, keyboard);
-
-fn keyboard() {
-    sprint!(".");
+#[no_mangle]
+fn ExceptionHandler(_trap_frame: &riscv_rt::TrapFrame) -> ! {
+    panic!("Exception Found!");
 }
 
 fn set_priv_to_machine() {
@@ -106,9 +153,14 @@ fn set_priv_to_machine() {
 
 fn enable_risc_interrupts() {
     unsafe {
-        riscv::register::mie::set_mtimer();
+        // riscv::register::mie::set_mtimer();
+        riscv::register::mie::set_mext();
+        riscv::register::mie::set_sext();
+        riscv::register::mie::set_uext();
         riscv::register::mstatus::set_mie();
-        sprintln!("Timer Interrupt Enabled");
+        riscv::register::mstatus::set_sie();
+        riscv::register::mstatus::set_uie();
+        sprintln!("Interrupts Enabled");
     }
 }
 
@@ -166,16 +218,15 @@ fn kmain() -> ! {
     // ready to start scheduling. The last thing this
     // should do is start the timer.
 
-    let dr = DeviceResources::take().unwrap();
+    let mut dr = DeviceResources::take().unwrap();
     let p = dr.peripherals;
     let pins = dr.pins;
 
     // Configure clocks
     let clocks = hifive1::clock::configure(p.PRCI, p.AONCLK, 320.mhz().into());
 
-    // Configure UART for stdout
-    let mut rx = hifive1::stdout::configure(
-        p.UART0,
+    // Configure UART0 for stdout
+    let _ = hifive1::stdout::configure(p.UART0,
         pin!(pins, uart0_tx),
         pin!(pins, uart0_rx),
         115_200.bps(),
@@ -188,47 +239,30 @@ fn kmain() -> ! {
     tleds.2.on();
 
     set_priv_to_machine();
-    update_time_compare((clocks.lfclk().0 / 1000) as u64);
+
+    dr.core_peripherals.plic.mext.enable();
+
+    unsafe {
+        let dr = DeviceResources::steal();
+        let uart = dr.peripherals.UART0;
+        // En
+        uart.ie.write(|w| w.txwm().bit(false).rxwm().bit(true));
+        uart.rxctrl.write(|w| w.enable().bit(true).counter().bits(0));
+
+        let mut plic = dr.core_peripherals.plic;
+        plic.uart0.enable();
+        plic.uart0.set_priority(Priority::P4);
+
+        plic.threshold.set(Priority::P0);
+    }
+    dr.core_peripherals.plic.threshold.set(hifive1::hal::core::plic::Priority::P0);
+    assert_eq!(0, unsafe {(*PLIC::ptr()).threshold.read().bits()});
+
     enable_risc_interrupts();
 
     sprintln!("Hello World, This is Rust Box");
 
     loop {
-        riscv::interrupt::free(|_| {
-            if let Ok(w) = rx.read() {
-                match w {
-                    8 | 127 => {
-                        sprint!("{}{}{}", 8 as char, ' ', 8 as char);
-                    },
-                    10 | 13 => {
-                        sprintln!();
-                        tleds.0.off();
-                        tleds.1.off();
-                        tleds.2.on();
-                    },
-                    _ => {
-                        sprint!("{}", w as char);
-                        let c = (w % 7) + 1; // 1 to 8
-                        if c as u8 & 1 == 1 {
-                            tleds.2.on();
-                        } else {
-                            tleds.2.off();
-                        }
-                        if c as u8 & 2 == 2 {
-                            tleds.1.on();
-                        } else {
-                            tleds.1.off();
-                        }
-                        if c as u8 & 4 == 4 {
-                            tleds.0.on();
-                        } else {
-                            tleds.0.off();
-                        }
-                    }
-                }
-            }
-        });
-
         unsafe {
             riscv::asm::wfi();
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,14 +140,11 @@ fn ExceptionHandler(_trap_frame: &riscv_rt::TrapFrame) -> ! {
 fn set_priv_to_machine() {
 
     sprintln!("Machine Priv Mode: {:?}", mstatus::read().mpp());
-    sprintln!("Supervisor Priv Mode: {:?}", mstatus::read().spp());
     unsafe {
         sprintln!("Setting to Machine/Supervisor");
         mstatus::set_mpp(mstatus::MPP::Machine);
-        mstatus::set_spp(mstatus::SPP::Supervisor);
     }
     sprintln!("Machine Priv Mode: {:?}", mstatus::read().mpp());
-    sprintln!("Supervisor Priv Mode: {:?}", mstatus::read().spp());
 }
 
 fn enable_risc_interrupts() {


### PR DESCRIPTION
The main thing we were missing previously I think was that we had to set the "high water mark interrupt level" and the interrupt enable on the memory mapped UART0 itself. After reading chapter 18 of https://sifive.cdn.prismic.io/sifive/654b2b4c-a6dd-4aef-afaf-f7ca89f99583_fe310-g002-manual-v1p0.pdf several times and then seeing the example code here: https://github.com/riscv-rust/riscv-rust-quickstart/blob/interrupt-test/examples/interrupt.rs I was able to get the UART to respond to key presses.

https://github.com/riscv-rust/hifive1/issues/21